### PR TITLE
fix: content.js:1 Uncaught TypeError: Promise.defer is not a function

### DIFF
--- a/content.js
+++ b/content.js
@@ -45,40 +45,41 @@ App.prototype = {
     init: function () {
         var self = this;
 
-        var defer = Promise.defer();
+        var defer = new Promise(function(resolve, reject){
+            document.onreadystatechange = function () {
+                if (document.readyState === 'interactive') {
+                    rootEl = document.documentElement;
 
-        document.onreadystatechange = function () {
-            if (document.readyState === 'interactive') {
-                rootEl = document.documentElement;
+                    var content;
+                    var body     = document.body || {children: []};
+                    var children = body.children;
+                    var pre      = children[0];
 
-                var content;
-                var body     = document.body || {children: []};
-                var children = body.children;
-                var pre      = children[0];
+                    if (children.length == 0) {
+                        content = body.textContent;
+                    }
 
-                if (children.length == 0) {
-                    content = body.textContent;
+                    if (pre && pre.nodeName == 'PRE'
+                        && pre.getAttribute('style')) {
+                        content = pre.textContent;
+                    }
+
+                    if (!content || !content.trim()) {
+                        reject();
+
+                        return chrome.runtime.sendMessage({
+                            action: 'cleanHeaders'
+                        });
+                    }
+
+                    resolve(content);
                 }
+            };
+        });
 
-                if (pre && pre.nodeName == 'PRE'
-                    && pre.getAttribute('style')) {
-                    content = pre.textContent;
-                }
-
-                if (!content || !content.trim()) {
-                    defer.reject();
-
-                    return chrome.runtime.sendMessage({
-                        action: 'cleanHeaders'
-                    });
-                }
-
-                defer.resolve(content);
-            }
-        };
 
         Promise.all([
-            defer.promise,
+            defer,
             new Promise(function (resolve, reject) {
                 chrome.storage.sync.get(function (options) {
                     self.options = options;


### PR DESCRIPTION
之前在谷歌商店反应过这个问题，但是作者似乎太忙无暇关注……
在最新的开发版或Canary版Chrome上无法正常运行，Console控制台报错：Promise.defer is not a function。看起来似乎是因为这个是一个过时的非标准方法，参见 http://stackoverflow.com/questions/27889687/promise-defer-browser-support

所以简单修改了下 :joy: 
