### PR TITLE
try to fix Promise.defer is not a function error in chrome dev version

### DIFF
--- a/content.js
+++ b/content.js
@@ -55,7 +55,7 @@ App.prototype = {
     init: function () {
         var self = this;
 
-        var defer = Promise.defer ?  Promise.defer() : deferInit();
+        var defer = typeof Promise.defer === 'function' ?  Promise.defer() : deferInit();
 
         document.onreadystatechange = function () {
             if (document.readyState === 'interactive') {

--- a/content.js
+++ b/content.js
@@ -39,13 +39,23 @@ function App() {
     this.init();
 }
 
+function deferInit() {
+    var deferred = {};
+    var promise = new Promise(function(resolve, reject) {
+        deferred.resolve = resolve;
+        deferred.reject  = reject;
+    });
+    deferred.promise = promise;
+    return deferred;
+}
+
 App.prototype = {
     constructor: App,
 
     init: function () {
         var self = this;
 
-        var defer = Promise.defer();
+        var defer = Promise.defer ?  Promise.defer() : deferInit();
 
         document.onreadystatechange = function () {
             if (document.readyState === 'interactive') {


### PR DESCRIPTION
I use chrome canary version , but console print error  `Promise.defer is not a function` .
so according the thread from http://stackoverflow.com/questions/27889687/promise-defer-browser-support , i fixed it . 

Change :  1. compatible with older. 2. make minimum effect
