### PR TITLE
Make previewable elements less distracting

### DIFF
--- a/css/prism.less
+++ b/css/prism.less
@@ -13,7 +13,6 @@
         bottom: 0;
         opacity: 0;
         visibility: hidden;
-        -webkit-transition: .2s ease;
         transition: .2s ease;
     }
 
@@ -384,7 +383,8 @@
     }
     .color, .abslength, .easing, .time, .angle, .fontfamily, .gradient, .entity, .url {
         cursor: help;
-        outline: 1px solid;
+        outline: 1px dotted rgba(0,0,0,.2);
+        outline-offset: 1px;
         // text-shadow: 0 1px #FFF, 0 0 .2em rgba(255, 102, 0, 0.5);
     }
     .url {


### PR DESCRIPTION
Hey, thanks for making this and for using Prism!

I made the previewable elements a little less distracting, as I was finding it hard to read the code with all these black rectangles all over the place.

![image](https://user-images.githubusercontent.com/175836/36762652-af59f054-1bf2-11e8-812a-63740e53c889.png)

instead of

![image](https://user-images.githubusercontent.com/175836/36762662-ba3b8564-1bf2-11e8-8f1c-6b99affdfc8c.png)

(I also removed -webkit-transition because you don’t need that anymore)